### PR TITLE
Make code work with FreeRADIUS 3.0.22 and above

### DIFF
--- a/rlm_attr_log.c
+++ b/rlm_attr_log.c
@@ -260,7 +260,13 @@ static int log_attrs_json(rlm_attr_log_t *inst, UNUSED REQUEST *request, RADIUS_
 
 		/* Add values */
 		for (;;) {
-			len = ( dv ? (size_t)snprintf(p, freespace, "\"%s\"", dv->name) :  vp_prints_value_json(p, freespace, vp) );
+			len = ( dv ?  (size_t)snprintf(p, freespace, "\"%s\"", dv->name) :
+#if RADIUSD_VERSION >= 030022
+				vp_prints_value_json(p, freespace, vp, true)
+#else
+				vp_prints_value_json(p, freespace, vp)
+#endif
+				);
 			if (len > freespace) goto no_space;
 			p += len;
 			freespace -= len;


### PR DESCRIPTION
This release has gotten an extra argument to the vp_prints_value_json, to control the translation from integer values to symbolic names. It would be nice if we could use this and drop our own translation code, but that would result in a minor behaviour change which we don't want.